### PR TITLE
Bugfix #31: Fix image form

### DIFF
--- a/Form/WidgetImageType.php
+++ b/Form/WidgetImageType.php
@@ -34,7 +34,6 @@ class WidgetImageType extends WidgetType
                 ])
                 ->add('lazyLoad', null, [
                     'label'          => 'widget_image.form.lazyLoad.label',
-                    'vic_help_label' => 'widget_image.form.lazyLoad.help_label',
                 ])
                 ->add('alt', null, [
                     'label'    => 'widget_image.form.alt.label',

--- a/Resources/views/form/image.html.twig
+++ b/Resources/views/form/image.html.twig
@@ -3,6 +3,6 @@
         {{ form_widget(form.image) }}
     </div>
     <div class="col-sm-12">
-        {{ form_row(form.lazyLoad) }}
+        {{ form_widget(form.lazyLoad) }}
     </div>
 </div>

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -19,7 +19,9 @@
             </div>
         </div>
         <h3 class="col-sm-12">{{ 'widget_image.form.link.label'|trans({}, 'victoire') }}</h3>
-        {{ form_widget(form.link) }}
+        <div class="col-sm-12">
+            {{ form_widget(form.link) }}
+        </div>
         <h3 class="col-sm-12">{{ 'widget_image.form.hover.label'|trans({}, 'victoire') }}</h3>
         <div class="col-sm-12">
             <div class="row">

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
   services:
     - redis
   php:
-    version: 7.1.0
+    version: 7.1.9
 
 checkout:
   post:


### PR DESCRIPTION
Display image input in a block
Remove useless help message (the text of checkbox display the same text)
Fix structure of HTML tags

Fixes #31

Here is the form after these changes:

![capture d ecran de 2017-12-27 15-11-04](https://user-images.githubusercontent.com/2071331/34383928-0e7df914-eb19-11e7-924c-acdac56602fd.png)